### PR TITLE
Fix Sonar Scanner parameter name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ public class Build extends JkClass {
 Execute `run` method from Sonaqube plugin after a build as `jeka clean java#pack sonarqube#run`.
 
 Sonarqube client can be configured programmatically using `sonarqube` instance and/or 
-using standard system properties from the command line as `-Dsonar.host=...` (see https://docs.sonarqube.org/latest/analysis/analysis-parameters/).
+using standard system properties from the command line as `-Dsonar.host.url=...` (see https://docs.sonarqube.org/latest/analysis/analysis-parameters/).
 
 ### Programmatically
 


### PR DESCRIPTION
 Should be `sonar.host.url` instead of `sonar.host` according to https://docs.sonarqube.org/latest/analysis/analysis-parameters/.

This will close #2.